### PR TITLE
fetch query from url parameter

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -8,7 +8,7 @@ scipy
 lxml
 requests
 matplotlib
-voila >= 0.1.20
+voila >= 0.2.2
 ipywidgets >= 7.5.1
 -e git+https://github.com/neuroquery/neuroquery.git#egg=neuroquery
 jupytext

--- a/minimal_dashboard.py
+++ b/minimal_dashboard.py
@@ -22,6 +22,9 @@
 
 # ## Encode a query into a statistical map of the brain
 
+import os
+from urllib.parse import parse_qs
+
 from neuroquery import fetch_neuroquery_model, NeuroQueryModel
 from neuroquery.tokenization import get_html_highlighted_text
 from nilearn.plotting import plot_img, view_img
@@ -41,7 +44,11 @@ face (self-recognition), is impaired, while other aspects of visual processing
 decision-making) remain intact. (from wikipedia)
 """.replace("\n", " ")
 
-query = widgets.Textarea(value=example_query)
+query_string = os.environ.get('QUERY_STRING', '')
+parameters = parse_qs(query_string)
+query_text=parameters.get('query', [example_query])[0]
+
+query = widgets.Textarea(value=query_text)
 button = widgets.Button(description="Run query")
 display(widgets.HBox([query, button]))
 output = widgets.Output()


### PR DESCRIPTION
This change allows the sharing of links pointing directly to a query, which is an important feature in the main neuroquery website.

For instance, try https://notebooks.gesis.org/binder/v2/gh/rprimet/neuroquery_apps/query_string?urlpath=%2Fvoila%2Frender%2Fminimal_dashboard.py%3Fquery%3Dadhd 

A further refinement would be to allow creating these sharing links from within the voilà dashboard itself, but this may require some introspection (see if we are running from within a binderhub service, obtain the hostname etc.)